### PR TITLE
ensure chart.credits exists before hiding

### DIFF
--- a/src/directives/highcharts-ng.js
+++ b/src/directives/highcharts-ng.js
@@ -194,7 +194,7 @@ angular.module('highcharts-ng', [])
         scope.$watch("config.credits.enabled", function (credits) {
           if (credits) {
             chart.credits.show();
-          } else {
+          } else if (chart.credits) {
             chart.credits.hide();
           }
         });


### PR DESCRIPTION
I noticed this when setting credits.enabled: false.
