### PR TITLE
merging tooltip property as well

### DIFF
--- a/src/directives/highcharts-ng.js
+++ b/src/directives/highcharts-ng.js
@@ -51,6 +51,7 @@ angular.module('highcharts-ng', [])
         title: {},
         subtitle: {},
         series: [],
+        tooltip: {},
         credits: {},
         plotOptions: {},
         navigator: {enabled: false}
@@ -94,6 +95,9 @@ angular.module('highcharts-ng', [])
       };
       if (config.subtitle) {
         mergedOptions.subtitle = config.subtitle;
+      };
+      if (config.tooltip) {
+        mergedOptions.tooltip = config.tooltip;
       };
       if (config.credits) {
         mergedOptions.credits = config.credits;


### PR DESCRIPTION
when I change tooltip configuration, it doesn't affect the instance of a highchart.

tooltip property hasn't been merged into config object, and because of that customizing tooltip doesn't work. this commit resolves the issue.
