### PR TITLE
Destroy chart when scope gets destroyed

### DIFF
--- a/src/directives/highcharts-ng.js
+++ b/src/directives/highcharts-ng.js
@@ -15,7 +15,7 @@ angular.module('highcharts-ng', [])
                 return i;
         return -1;
     };
-    
+
 
     function prependMethod(obj, method, func) {
       var original = obj[method];
@@ -256,6 +256,12 @@ angular.module('highcharts-ng', [])
           if (newOptions === oldOptions) return;
           initChart();
         }, true);
+
+        scope.$on('$destroy', function() {
+          if (chart) chart.destroy();
+          element.remove();
+        });
+
       }
     };
   });


### PR DESCRIPTION
Hi,

I'm currently creating an Angular app using highcharts-ng to draw different types of graphs. Today I noticed that my app was leaking quite much memory when I switched between views/routes. I had a look at highcharts-ng code, and saw that the chart does not get destroyed if scope is destroyed.

I created a simple test case app to see if I can verify the increased memory usage. I added a few routes to load 1-3 simple bar graphs to the test page each time a link got clicked.

Without this fix the memory usage would always stabilize itself to ~9.5mb after GC runs, but with this fix the memory usage was always ~8.4mb after memory was cleaned. So, over 1mb of memory savings for a very simple test app.
