### PR TITLE
Fixed Issue # 66, return a copy of options for charts with data

### DIFF
--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -128,7 +128,7 @@ angular.module('highcharts-ng', [])
     };
 
     var chartOptionsWithoutEasyOptions = function (options) {
-      return angular.extend({}, options, {data: null, visible: null});
+      return angular.copy(angular.extend({}, options, {data: options.data, visible: null}));
     };
 
     var prevOptions = {};


### PR DESCRIPTION
Related to Issue#66. It should return a copy of the prevOptions with the correct data mapped rather than the reference.

After this fix, the chart is able to update the same series with a new value and redraw it.

thanks :)
