### PR TITLE
fix chart not resetting after config.options is changed

### DIFF
--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -171,9 +171,7 @@ angular.module('highcharts-ng', [])
                   if (s.visible !== undefined && chartSeries.visible !== s.visible) {
                     chartSeries.setVisible(s.visible, false);
                   }
-                  if (chartSeries.options.data !== s.data) {
-                    chartSeries.setData(angular.copy(s.data), false);
-                  }
+                  chartSeries.setData(angular.copy(s.data), false);
                 }
               } else {
                 chart.addSeries(angular.copy(s), false);
@@ -196,6 +194,7 @@ angular.module('highcharts-ng', [])
         var chart = false;
         var initChart = function() {
           if (chart) chart.destroy();
+          prevSeriesOptions = {};
           var config = scope.config || {};
           var mergedOptions = getMergedOptions(scope, element, config);
           chart = config.useHighStocks ? new Highcharts.StockChart(mergedOptions) : new Highcharts.Chart(mergedOptions);


### PR DESCRIPTION
I was getting problems like series not showing up while using the following pattern:

```
var resetCount = 0;
// this is a trick. Whenever $scope.config.options changes (using angular.equals)
// highcharts-ng does initChart. So we change $scope.config.options.resetCount
// whenever our data completely changes.

$scope.$watch('settings.country', function (newValue) {
   resetCount++;
   $scope.chartConfig = {
      options: {resetCount: resetCount, tooltip: {shared: false}},
      series: [{id: "revenue", name: "revenue": ...}, ...]
   };
}
```

i.e. reusing the same chart id but expecting a completely new chart to be drawn.

This fixes that!
