### PR TITLE
Fix highchartsNgConfig object

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,53 +18,57 @@ The highchartsNgConfig resembles an exploded highcharts options object:
 
 
 ```javascript
-highchartsNgConfig = {
-             //This is not a highcharts object. It just looks a little like one!
-             options: {
-                 //This is the Main Highcharts chart config. Any Highchart options are valid here.
-                 //will be ovverriden by values specified below.
-                 chart: {
-                     type: 'bar'
-                 },
-                 tooltip: {
-                     style: {
-                         padding: 10,
-                         fontWeight: 'bold'
-                     }
-                 },
-             },
+    $scope.highchartsNgConfig = {
+        //This is not a highcharts object. It just looks a little like one!
+        options: {
+            //This is the Main Highcharts chart config. Any Highchart options are valid here.
+            //will be ovverriden by values specified below.
+            chart: {
+                type: 'bar'
+            },
+            tooltip: {
+                style: {
+                    padding: 10,
+                    fontWeight: 'bold'
+                }
+            },
+        },
 
-             //The below properties are watched separately for changes.
+        //The below properties are watched separately for changes.
 
-             //Series object (optional) - a list of series using normal highcharts series options.
-             series: [{
-                 data: [10, 15, 12, 8, 7]
-             }],
-             //Title configuration (optional)
-             title: {
-                 text: 'Hello'
-             },
-             //Boolean to control showng loading status on chart (optional)
-             loading: false,
-             //Configuration for the xAxis (optional). Currently only one x axis can be dynamically controlled.
-             //properties currentMin and currentMax provied 2-way binding to the chart's maximimum and minimum
-             xAxis: {
-              currentMin: 0,
-              currentMax: 20,
-              title: {text: 'values'}
-             },
-             //Whether to use HighStocks instead of HighCharts (optional). Defaults to false.
-             useHighStocks: false
-             },
-             //size (optional) if left out the chart will default to size of the div or something sensible.
-             size: {
-               width: 400,
-               height: 300
-             },
-             //function (optional)
-             func: function (chart) {
-               //setup some logic for the chart
-             }
+        //Series object (optional) - a list of series using normal highcharts series options.
+        series: [{
+            data: [10, 15, 12, 8, 7]
+        }],
+        //Title configuration (optional)
+        title: {
+            text: 'Hello'
+        },
+        //Boolean to control showng loading status on chart (optional)
+        loading: false,
+        //Configuration for the xAxis (optional). Currently only one x axis can be dynamically controlled.
+        //properties currentMin and currentMax provied 2-way binding to the chart's maximimum and minimum
+        xAxis: {
+            currentMin: 0,
+            currentMax: 20,
+            title: {
+                text: 'values'
+            }
+        },
+        //Whether to use HighStocks instead of HighCharts (optional). Defaults to false.
+        useHighStocks: false,
+
+        //size (optional) if left out the chart will default to size of the div or something sensible.
+        size: {
+            width: 400,
+            height: 300
+        },
+        //function (optional)
+        func: function(chart) {
+            //setup some logic for the chart
+        }
+
+    };
 ```
 
 All properties on the chart configuration are optional. If you don't need a feature best to leave it out completely - Highcharts will usually default to something sensible. Each property is watched for changes by angularjs.
@@ -92,6 +96,7 @@ Caveats:
 - The 2 way binding to xAxis properties should be treated as experimental
 - When using with a highstocks navigator errors can occur
 - Needs tests!
+- Requires JQuery
 
 
 Versions


### PR DESCRIPTION
highchartsNgConfig had an extra bracket in it. 

Thought I'd mention the point about JQuery, as it suggests further down the readme that the JQuery dependency has been removed. 
