### PR TITLE
fix: Detect changes in config.options

### DIFF
--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -306,8 +306,6 @@ angular.module('highcharts-ng', [])
           }, true);
         });
         scope.$watch('config.options', function (newOptions, oldOptions, scope) {
-          //do nothing when called on registration
-          if (newOptions === oldOptions) return;
           initChart();
           processSeries(scope.config.series);
           chart.redraw();


### PR DESCRIPTION
Due to how deep watching works, `newOptions === oldOptions` will always be true so callbacks is always going to be skipped. Deep watching doesn't check if `newOptions !== oldOptions` but recursively checks for changes.

This is fix for `options` parameter but I'd also remove such checks from the rest of deep watches.
