### PR TITLE
Updates highstock option typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ highchartsNgConfig = {
               title: {text: 'values'}
              },
              //Whether to use HighStocks instead of HighCharts (optional). Defaults to false.
-             useHighStocks: false
+             useHighStock: false
              },
              //size (optional) if left out the chart will default to size of the div or something sensible.
              size: {


### PR DESCRIPTION
This updates a typo in the readme regarding how to enable HighStocks. The correct variable name is `useHighStock`. Using the other name leads to JS errors.
