### PR TITLE
updated the processSeries method to not remove the navigator series that...

### DIFF
--- a/dist/highcharts-ng.js
+++ b/dist/highcharts-ng.js
@@ -189,7 +189,7 @@ angular.module('highcharts-ng', []).factory('highchartsNGUtils', function () {
           }
           for (i = chart.series.length - 1; i >= 0; i--) {
             var s = chart.series[i];
-            if (highchartsNGUtils.indexOf(ids, s.options.id) < 0) {
+            if (s.options.id !== 'highcharts-navigator-series' && highchartsNGUtils.indexOf(ids, s.options.id) < 0) {
               s.remove(false);
             }
           }

--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -228,7 +228,7 @@ angular.module('highcharts-ng', [])
           //Now remove any missing series
           for(i = chart.series.length - 1; i >= 0; i--) {
             var s = chart.series[i];
-            if (highchartsNGUtils.indexOf(ids, s.options.id) < 0) {
+            if (s.options.id !== 'highcharts-navigator-series' && highchartsNGUtils.indexOf(ids, s.options.id) < 0) {
               s.remove(false);
             }
           }


### PR DESCRIPTION
The processSeries method is removing the auto generated series that is added to the chart when using a separate data set for the navigator like so:

```
options: {
        navigator: {
            series: {
                data: [/*some custom navigator data*/]
            }
        }
}
```

This was causing the navigator to be be blank.
