### PR TITLE
Performance Improvement: removed conditional in processSeries()

### DIFF
--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -184,7 +184,7 @@
 
           if(series) {
             var setIds = ensureIds(series);
-            if(setIds && !scope.disableDataWatch) {
+            if(setIds) {
               //If we have set some ids this will trigger another digest cycle.
               //In this scenario just return early and let the next cycle take care of changes
               return false;


### PR DESCRIPTION
For users disabling the deep data series watch, this 'return true' block would never run.  This often led to more processing than necessary, causing a significant performance impact (double).  If users weren't disabling the deep data series watch, this code always ran the same as it did before.  Removing the unnecessary conditional doesn't change behavior for people with default data series watch (enabled), but improves performance for people who have disabled the deep data series watching.
