### PR TITLE
Added an 'exportChart' event.

### DIFF
--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -335,6 +335,12 @@
         scope.$on('highchartsng.reflow', function () {
           chart.reflow();
         });
+        
+        scope.$on('exportChart', function() {
+          if (chart) {
+            chart.exportChart();
+          }
+        });
 
         scope.$on('$destroy', function() {
           if (chart) {


### PR DESCRIPTION
I needed to have a way to export the chart with a custom button, instead of the default built-in one.

This listens to an 'exportChart' event, which will call the exportChart function on the Highchart.Chart object.

Example use:

```
    $scope.$broadcast('exportChart');
```

As simple as that!
