### PR TITLE
add basic tests

### DIFF
--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -7,7 +7,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
 
   angular.module('highcharts-ng', [])
     .factory('highchartsNGUtils', highchartsNGUtils)
-    .directive('highchart', ['highchartsNGUtils', highchart]);
+    .directive('highchart', ['highchartsNGUtils', '$timeout', highchart]);
 
   function highchartsNGUtils() {
 
@@ -58,7 +58,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
     };
   }
 
-  function highchart(highchartsNGUtils) {
+  function highchart(highchartsNGUtils, $timeout) {
 
     // acceptable shared state
     var seriesId = 0;
@@ -342,7 +342,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
         scope.$on('$destroy', function() {
           if (chart) {
             chart.destroy();
-            setTimeout(function(){
+            $timeout(function(){
               element.remove();
             }, 0);
           }


### PR DESCRIPTION
This expands the specs by a few simple assertions. The only change to the directive is the use of `$timeout` instead of `setTimeout` for cleaner tests. This was already a proposed change in #124.
