### PR TITLE
Fix 240 - use deepExtend to copy series for comparison to include marker...

### DIFF
--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -163,7 +163,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
     };
 
     var chartOptionsWithoutEasyOptions = function (options) {
-      return angular.extend({}, options, {data: null, visible: null});
+      return highchartsNGUtils.deepExtend({}, options, {data: null, visible: null});
     };
 
     return {


### PR DESCRIPTION
Fix for issue #240 - marker options not being watched.  Switched from using angular.extend which does not support deep copying, and so misses the nested marker options, such as radius and symbol, to now using the highchartsNGUtils.deepExtend function.  Local testing does not show any performance issues.