### PR TITLE
add browserify support and prep for publishing on npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,16 @@
+/bower_components/
+/node_modules/
+npm-debug.log
+
+/.idea/
+.DS_Store
+
+/test/
+/src/
+/example/
+.editorconfig
+bower.json
+CONTRIBUTING.md
+Gruntfile.js
+karma.conf.js
+README.md

--- a/package.json
+++ b/package.json
@@ -47,5 +47,6 @@
   },
   "scripts": {
     "test": "grunt test"
-  }
+  },
+  "browser": "./dist/highcharts-ng.js"
 }


### PR DESCRIPTION
added browser property to package to be compatible with browserify.  Also added .npmignore in hopes that you publish to NPM as well, but if not I guess I can continue to point to your github in my package.