### PR TITLE
data update breaks animation

### DIFF
--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -168,7 +168,11 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
     };
 
     var chartOptionsWithoutEasyOptions = function (options) {
-      return highchartsNGUtils.deepExtend({}, options, {data: null, visible: null});
+        return
+            angular.extend(
+                highchartsNGUtils.deepExtend({}, options),
+                { data: null, visible: null }
+            );
     };
 
     var getChartType = function(scope) {

--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -168,10 +168,10 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
     };
 
     var chartOptionsWithoutEasyOptions = function (options) {
-        return angular.extend(
+      return angular.extend(
           highchartsNGUtils.deepExtend({}, options),
           { data: null, visible: null }
-        );
+      );
     };
 
     var getChartType = function(scope) {

--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -168,11 +168,10 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
     };
 
     var chartOptionsWithoutEasyOptions = function (options) {
-        return
-            angular.extend(
-                highchartsNGUtils.deepExtend({}, options),
-                { data: null, visible: null }
-            );
+        return angular.extend(
+          highchartsNGUtils.deepExtend({}, options),
+          { data: null, visible: null }
+        );
     };
 
     var getChartType = function(scope) {

--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -169,8 +169,8 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
 
     var chartOptionsWithoutEasyOptions = function (options) {
       return angular.extend(
-          highchartsNGUtils.deepExtend({}, options),
-          { data: null, visible: null }
+        highchartsNGUtils.deepExtend({}, options),
+        { data: null, visible: null }
       );
     };
 


### PR DESCRIPTION
the call of highchartsNGUtils.deepExtend({}, options, {data: null, visible: null});

does not set the options.data to null, therefore the data update was executed through a series.update and not a series.setData -> in the processSeries function. Wrapping an angular.extend around should solve the problem with data and visible attributes.