### PR TITLE
Make all user defined options can be taken by highcharts-ng

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple Angularjs directive for Highcharts.
 
 Google Group: https://groups.google.com/forum/#!forum/highcharts-ng
 
-Current Version (0.0.8)
+Current Version (0.0.9)
 ---------------
 
 **Setup:**
@@ -190,6 +190,10 @@ This forces the chart to reflow after container and chart have finished renderin
 
 Versions
 --------------
+
+Versions 0.0.9
+--------------
+- Make all user defined options can be taken by highcharts-ng
 
 Version 0.0.8
 ----------------

--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -134,22 +134,8 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
         }
       });
 
-      if(config.title) {
-        mergedOptions.title = config.title;
-      }
-      if (config.subtitle) {
-        mergedOptions.subtitle = config.subtitle;
-      }
-      if (config.credits) {
-        mergedOptions.credits = config.credits;
-      }
-      if(config.size) {
-        if (config.size.width) {
-          mergedOptions.chart.width = config.size.width;
-        }
-        if (config.size.height) {
-          mergedOptions.chart.height = config.size.height;
-        }
+      for (var propertyName in config) {
+          mergedOptions[propertyName] = config[propertyName];
       }
       return mergedOptions;
     };


### PR DESCRIPTION
There are many Highcharts API not be supported by highcharts-ng. The main reason is the merged options only takes some config from user defined object (ex: title, subtitle, credits... etc). I think highcharts-ng should take all the user config then used the default options if user doesn't define it.