### PR TITLE
Add check for if we disabled data watching or not

### DIFF
--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -198,7 +198,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
 
           if(series) {
             var setIds = ensureIds(series);
-            if(setIds) {
+            if(setIds && !scope.disableDataWatch) {
               //If we have set some ids this will trigger another digest cycle.
               //In this scenario just return early and let the next cycle take care of changes
               return false;


### PR DESCRIPTION
If user enables `disableDataWatch`, then we watch using `watchCollection` instead of deep `watch`. In this scenario second digest cycle is not triggered and series are not drawn into the chart.