### PR TITLE
fix(deepExtend): Ensure dest is obj when src is obj

### DIFF
--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -111,6 +111,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
             destination[i] = deepExtend(destination[i] || {}, source[i]);
           }
         } else if (angular.isObject(source)) {
+          destination = angular.isObject(destination) ? destination : {};
           for (var property in source) {
             destination[property] = deepExtend(destination[property] || {}, source[property]);
           }

--- a/test/spec/highcharts-ng-utils.js
+++ b/test/spec/highcharts-ng-utils.js
@@ -23,7 +23,7 @@ describe('Module: highchartsNg', function () {
     var noop = function(){};
     var source = {bar: 'abc', arr: [1, 'two', {}], nested: {a: {b: 2}}, fn: noop},
       dest;
-    highchartsNG.deepExtend(dest, source);
+    dest = highchartsNG.deepExtend(dest, source);
     expect('abc').toEqual(dest.bar);
     expect([1, 'two', {}]).toEqual(dest.arr);
     expect(noop).toEqual(dest.fn);

--- a/test/spec/highcharts-ng-utils.js
+++ b/test/spec/highcharts-ng-utils.js
@@ -18,5 +18,19 @@ describe('Module: highchartsNg', function () {
     expect({c: 5, a: {b : 2}}).toEqual(dest.nested);
     expect(source.nested).not.toBe(dest.nested);
   }));
+  
+  it('should extend undefined', inject(function (highchartsNG) {
+    var noop = function(){};
+    var source = {bar: 'abc', arr: [1, 'two', {}], nested: {a: {b: 2}}, fn: noop},
+      dest = undefined;
+    highchartsNG.deepExtend(dest, source);
+    expect('abc').toEqual(dest.bar);
+    expect([1, 'two', {}]).toEqual(dest.arr);
+    expect(noop).toEqual(dest.fn);
+    expect(source.arr).not.toBe(dest.arr);
+    expect(source.arr[2]).not.toBe(dest.arr[2]);
+    expect({a: {b : 2}}).toEqual(dest.nested);
+    expect(source.nested).not.toBe(dest.nested);
+  }));
 
 });

--- a/test/spec/highcharts-ng-utils.js
+++ b/test/spec/highcharts-ng-utils.js
@@ -22,7 +22,7 @@ describe('Module: highchartsNg', function () {
   it('should extend undefined', inject(function (highchartsNG) {
     var noop = function(){};
     var source = {bar: 'abc', arr: [1, 'two', {}], nested: {a: {b: 2}}, fn: noop},
-      dest = undefined;
+      dest;
     highchartsNG.deepExtend(dest, source);
     expect('abc').toEqual(dest.bar);
     expect([1, 'two', {}]).toEqual(dest.arr);


### PR DESCRIPTION
currently `deepExtend` is not ensuring the `destination` is an object when the source is an object.
`deepExtend` currently does a [similar check/set for the case of `source` being an array](https://github.com/pablojim/highcharts-ng/blob/a874fdd0d7ca0c40abbfe13e8e3c00f7490c6f8b/src/highcharts-ng.js#L109).
This PR adds the check for `destination` being an object and if not sets it to `{}`.