### PR TITLE
Fix for loading label when there is no data

### DIFF
--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -372,7 +372,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
       });
       scope.$watch('config.noData', function (noData) {
         if(scope.config && scope.config.loading) {
-          chart.showLoading(noData);
+          chart.showLoading(scope.config.loading);
         }
       }, true);
 


### PR DESCRIPTION
Loading label with custom string won't show if there is no data.
