### PR TITLE
Add credits.enabled property to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,10 @@ var chartConfig = {
   xAxis: {
   currentMin: 0,
   currentMax: 20,
-  title: {text: 'values'}
+  title: {text: 'values'},
+  credits: {
+      enabled: true
+  }
   },
   //Whether to use Highstocks instead of Highcharts (optional). Defaults to false.
   useHighStocks: false,


### PR DESCRIPTION
credits was in the source code as a supported option, but not documented for new users.