### PR TITLE
Add highcharts as dependacy in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,8 +19,12 @@
   "main": "dist/highcharts-ng.js",
   "license": "MIT",
   "authors": [
-    { "name": "Barry Fitzgerald" }
+    {
+      "name": "Barry Fitzgerald"
+    }
   ],
-  "dependencies": {},
+  "dependencies": {
+    "highcharts": "~5.0.4"
+  },
   "devDependencies": {}
 }


### PR DESCRIPTION
when installing the module it's not working and after investigations I found that the highcharts is not included in the scripts list, and after installing it every thing goes well, so I add it as dependancy in the bower file