### PR TITLE
Checking for existence of chart before reflow.

### DIFF
--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -49,7 +49,9 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
       var originalHeight = $element[0].clientHeight;
       $timeout(function () {
         if ($element[0].clientWidth !== originalWidth || $element[0].clientHeight !== originalHeight) {
-          ctrl.chart.reflow();
+          if (ctrl.chart) {
+            ctrl.chart.reflow();
+          }
         }
       }, 0, false);
     };


### PR DESCRIPTION
Fixes an issue where rapidly replacing the chart config can lead to this being called before the chart is ready and throwing an error. Also, given that this is in a timeout and therefore the method is called after the initiating render cycle, it makes sense to make sure there's something to act upon.

![image](https://user-images.githubusercontent.com/690210/30343826-b04f2128-97b3-11e7-8181-f3cfb23c6c5a.png)

NOTE: we came upon this issue because we realized that simply swapping the config rapidly actually caused a series of bugs if the user still had tooltips visible, as they could not be destroyed correctly and rebuilt. Our fix was to first set the config to `null` and then set it to the new config on the next draw cycle to avoid this, but it resulted in this issue. I think the correct fix might be addressing that concern as well: I can provide a repro path for it if needed, but this was a relatively easy workaround and also seems logical given the use of a timeout.
