### PR TITLE
Highcharts-ng Example Corrections

### DIFF
--- a/example/charts/app.js
+++ b/example/charts/app.js
@@ -58,7 +58,7 @@ $scope.addAxis = function(xy) {
   */
   var id;
   var axis;
-  if (xy==='Y') {
+  if (xy==='y') {
     yAxisId += 1;
     id = yAxisId;
     axis = 'yAxis';

--- a/example/charts/highstocks-example.html
+++ b/example/charts/highstocks-example.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.0.8/angular.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.8/angular.min.js"></script>
     <script src="http://code.highcharts.com/stock/highstock.src.js"></script>
     <script src="../../src/highcharts-ng.js"></script>
     <script src="highstocks-app.js"></script>

--- a/example/maps/app.js
+++ b/example/maps/app.js
@@ -72,17 +72,16 @@ angular
         };
 
         this.config = {
-            options: {
-                legend: {
-                    enabled: false
-                },
-                plotOptions: {
-                    map: {
-                        mapData: Highcharts.maps['custom/world'],
-                        joinBy: ['name']
-                    }
-                },
+            legend: {
+                enabled: false
             },
+            plotOptions: {
+                map: {
+                    mapData: Highcharts.maps['custom/world'],
+                    joinBy: ['name']
+                }
+            },
+            animation: true,
             chartType: 'map',
             title: {
                 text: 'Highcharts-ng map example'

--- a/example/maps/example.html
+++ b/example/maps/example.html
@@ -12,11 +12,10 @@
         </style>
 
         <script src="http://code.highcharts.com/adapters/standalone-framework.js"></script>
-        <script src="http://code.highcharts.com/highcharts.js"></script>
-        <script src="http://code.highcharts.com/maps/modules/map.js"></script>
-        <script src="http://code.highcharts.com/mapdata/custom/world.js"></script>
-
-        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.28/angular.min.js"></script>
+        <script src="http://code.highcharts.com/highcharts.js"></script> 
+        <script src="http://code.highcharts.com/maps/modules/map.js"></script> 
+        <script src="http://code.highcharts.com/mapdata/custom/world.js"></script> 
+        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.8/angular.min.js"></script>
         <script src="../../dist/highcharts-ng.min.js"></script>
         <script src="app.js"></script>
     </head>


### PR DESCRIPTION
Bumped Angular Version to 1.5.8 where necessary to allow component declaration.
Refactored Config object on Maps example to vanilla.
Adjusted comparator in General example, strong comparison was failing since it was checking for uppercase character.