### PR TITLE
Added npm build script for building with local grunt.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "phantomjs-prebuilt": "^2.1.7"
   },
   "scripts": {
+    "build": "grunt",
     "test": "grunt test"
   },
   "main": "./dist/highcharts-ng",


### PR DESCRIPTION
@pablojim thank you for making and sharing highcharts-ng! I have two motivations for this PR,

1. I ran into the issue fixed in #592 and request that the fix be published to npm (perhaps as version 1.2.1)
2. Because `1.2.1-dev` wasn't rebuilt (the dist folder still had `1.2.0`), I forked the repo to create a build. I don't have grunt installed globally, preferring npm scripts these day because they can keep dependencies local. This is a pattern adopted by many since npm scripts will fix up the path to allow for local dependencies and for conventional targets like `npm run build`. Just looking at some other examples, angular.js uses a script wrapper for the grunt command in their [package.json](https://github.com/angular/angular.js/blob/62e2ec18e65f15db4f52bb9f695a92799c58b5f1/package.json#L20) and vue.js uses a build script wrapper in their [package.json](https://github.com/vuejs/vue/blob/782b66c790cee4a4998f48704bd0b8f643a43aca/package.json#L25). Personally, I favor a `build` script over a `grunt` script but that's preference. Since you have a default build target in your gruntfile, you have the added advantage of being able to provide a build target by simply wrapping grunt. For example, `npm run build -- watch` will run the equivalent of `grunt watch`.

Feel free to close this PR. The main motivation is the need for a new version. But, I do think npm scripts are a popular option these days as well. 

Thank you for your time and consideration.